### PR TITLE
Updating dust value to align with https://github.com/bitcoin-sv/bitco…

### DIFF
--- a/src/forge.js
+++ b/src/forge.js
@@ -11,8 +11,7 @@ import {
 import Cast from './cast'
 import { P2PKH, OP_RETURN } from './casts'
 
-// Constants
-const DUST_LIMIT = 135
+const DEFAULT_DUST_LIMIT = 546 // 546 sats remains spendable however since bitcoin-sv v1.0.5 miners will mine consolidatable-dust >= 135 sats
 
 // Default Forge options
 const defaults = {
@@ -20,7 +19,8 @@ const defaults = {
   rates: {
     data: 0.5,
     standard: 0.5
-  }
+  },
+  dustLimit: DEFAULT_DUST_LIMIT // Overridable via constructor e.g: new Forge(options: {dustLimit: 135 })
 }
 
 /**
@@ -236,7 +236,7 @@ class Forge {
       const isOpReturn = (script.chunks[0].opCodeNum === OpCode.OP_RETURN ||
         (script.chunks[0].opCodeNum === OpCode.OP_FALSE && script.chunks[1].opCodeNum === OpCode.OP_RETURN)
       )
-      if (cast.satoshis < DUST_LIMIT && !isOpReturn) {
+      if (cast.satoshis < this.options.dustLimit && !isOpReturn) {
         throw new Error('Cannot create output lesser than dust')
       }
       this.tx.addTxOut(Bn(cast.satoshis), script)
@@ -253,7 +253,7 @@ class Forge {
         change -= 16
       }
 
-      if (change > DUST_LIMIT) {
+      if (change > this.options.dustLimit) {
         this.tx.addTxOut(TxOut.fromProperties(Bn(change), this.changeScript))
       }
     }

--- a/src/forge.js
+++ b/src/forge.js
@@ -12,7 +12,7 @@ import Cast from './cast'
 import { P2PKH, OP_RETURN } from './casts'
 
 // Constants
-const DUST_LIMIT = 546
+const DUST_LIMIT = 135
 
 // Default Forge options
 const defaults = {


### PR DESCRIPTION
…in-sv/releases/tag/v1.0.5

As can be seen here:
https://github.com/bitcoin-sv/bitcoin-sv/blob/782c043fb39060bfc12179792a590b6405b91f3c/src/test/transaction_tests.cpp#L651
And here:
https://github.com/bitcoin-sv/bitcoin-sv/blob/782c043fb39060bfc12179792a590b6405b91f3c/test/functional/dustrelayfee.py

The minimum dust threshold has been reduced to 135 and miners running bsv-1.0.5 are mining txs with values just higher than that e.g 140 satoshis here: https://whatsonchain.com/tx/75386e3f14e1507355fb9780b24aa70c42c9338e9e1a7b479bffb4d57e94c0c5

Perhaps you would prefer it to be added to the default options to allow for overriding? If so, let me know. 

Thanks
