### PR TITLE
Fix an error when specifying only M < N keypairs to sign a p2ms utxo

### DIFF
--- a/src/casts/p2ms.js
+++ b/src/casts/p2ms.js
@@ -106,8 +106,10 @@ const P2MS = {
           let keyPair = keyPairs.find(k => {
             return Buffer.compare(txOut.script.chunks[i].buf, k.pubKey.toBuffer()) === 0
           })
-          const sig = tx.sign(keyPair, sighashType, txOutNum, txOut.script, txOut.valueBn, flags)
-          script.writeBuffer(sig.toTxFormat())
+          if (keyPair) {
+            const sig = tx.sign(keyPair, sighashType, txOutNum, txOut.script, txOut.valueBn, flags)
+            script.writeBuffer(sig.toTxFormat())
+          }
         }
         return script
       }

--- a/test/casts/p2ms.test.js
+++ b/test/casts/p2ms.test.js
@@ -73,6 +73,13 @@ describe('P2MS.unlockingScript', () => {
     assert.isTrue(bsv.Sig.IsTxDer(script.chunks[3].buf))
   })
 
+  it('getScript() returns P2MS unlocking script when M < N correct keypairs provided', () => {
+    const script = cast.getScript(forge, { keyPairs: [keyPairs[0], keyPairs[2]] })
+    assert.lengthOf(script.chunks, 3)
+    assert.isTrue(bsv.Sig.IsTxDer(script.chunks[1].buf))
+    assert.isTrue(bsv.Sig.IsTxDer(script.chunks[2].buf))
+  })
+
   it('getScript() throws error when incorrect keyPair', () => {
     const keyPairs = [bsv.KeyPair.fromRandom()]
     assert.throws(_ => cast.getScript(forge, { keyPairs }), 'P2MS unlockingScript keyPairs must match lockingScript pubKeys')


### PR DESCRIPTION
P2MS should allow specifying M < N correct keypairs to sign. 
However, the following code results in an error:

```
redeemP2MSTXForge
  .build()
  .signTxIn(0, { keyPairs: [kp1, kp3] })    // suppose there are 3 possible keypairs kp1, kp2 and kp3.
```